### PR TITLE
remove post processing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,11 +144,3 @@ jobs:
 
       - name: Read settings
         uses: fscpscollaborative/fscps.gh/ReadSettings@v2.1
-
-      - name: Finalize the workflow
-        id: PostProcess
-        uses: fscpscollaborative/fscps.gh/WorkflowPostProcess@v2.1
-        with:
-          remove_current: ${{ needs.Initialization.outputs.environments == '' }}
-          settingsJson: ${{ env.Settings }}
-          secretsJson: ${{ env.RepoSecrets }}


### PR DESCRIPTION
The post processing tries to cleanup action runs and the workspace folder. Deleting runs requires a token, which is not available.

The deletion of runs only occurs for scheduled runs.