### PR TITLE
Changing Telemetry parameters table

### DIFF
--- a/src/Projects/ISM-Telemetry/ISM-Telemetry.rnrproj
+++ b/src/Projects/ISM-Telemetry/ISM-Telemetry.rnrproj
@@ -208,6 +208,11 @@
       <Name>ISMTelemetryParameters</Name>
       <Link>Base objects\ISMTelemetryParameters</Link>
     </Content>
+    <Content Include="AxTable\ISMTelemetryParameterSetup">
+      <SubType>Content</SubType>
+      <Name>ISMTelemetryParameterSetup</Name>
+      <Link>Tables\ISMTelemetryParameterSetup</Link>
+    </Content>
     <Content Include="ISM.en-US.label.txt">
       <SubType>Content</SubType>
       <Name>ISM.en-US.label.txt</Name>
@@ -223,6 +228,7 @@
     <Folder Include="JsonSerializer" />
     <Folder Include="BusinessEvent" />
     <Folder Include="CostActivation" />
+    <Folder Include="Tables\" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.Common.targets" />
   <Import Project="$(BuildTasksDirectory)\Microsoft.Dynamics.Framework.Tools.BuildTasks.17.0.targets" />

--- a/src/xpp/Metadata/ISMModel/ISMModel/AxClass/ISMTelemetryBase.xml
+++ b/src/xpp/Metadata/ISMModel/ISMModel/AxClass/ISMTelemetryBase.xml
@@ -17,7 +17,7 @@ abstract class ISMTelemetryBase
 
     System.Diagnostics.Stopwatch stopWatch = new System.Diagnostics.Stopwatch();
 
-    protected ISMTelemetryParameters logParams;
+    protected ISMTelemetryParameterSetup logParams;
 
     //you can fill this field or not, if you don't fill it, it will be set to 0
     protected str eventId;
@@ -33,7 +33,7 @@ abstract class ISMTelemetryBase
         stopWatch = new System.Diagnostics.Stopwatch();
         stopWatch.Start();
 
-        logParams = ISMTelemetryParameters::find(this.telemetryName());
+        logParams = ISMTelemetryParameterSetup::find(this.telemetryName());
 
         if (!logParams)
         {

--- a/src/xpp/Metadata/ISMModel/ISMModel/AxClass/ISMTelemetryEventHandler.xml
+++ b/src/xpp/Metadata/ISMModel/ISMModel/AxClass/ISMTelemetryEventHandler.xml
@@ -43,7 +43,7 @@ internal final class ISMTelemetryEventHandler
                 ClassId childClassId = listEnumerator.current();
                 TreeNode childClassNode = TreeNode::findNode(#ClassesPath + #AOTDelimiter + classId2Name(childClassId));
 
-                ISMTelemetryParameters param = ISMTelemetryParameters::find(childClassNode.AOTname());
+                ISMTelemetryParameterSetup param = ISMTelemetryParameterSetup::find(childClassNode.AOTname());
 
                 if (!param)
                 {

--- a/src/xpp/Metadata/ISMModel/ISMModel/AxFormExtension/SysIntParameters.ISM.xml
+++ b/src/xpp/Metadata/ISMModel/ISMModel/AxFormExtension/SysIntParameters.ISM.xml
@@ -63,17 +63,16 @@
 										<FormControlExtension
 											i:nil="true" />
 										<DataField>TelemetryClass</DataField>
-										<DataSource>ISMTelemetryParameters</DataSource>
+										<DataSource>ISMTelemetryParameterSetup</DataSource>
 									</AxFormControl>
 									<AxFormControl xmlns=""
-										i:type="AxFormComboBoxControl">
+										i:type="AxFormCheckBoxControl">
 										<Name>ISMTelemetryLogParam_IsEnabled</Name>
-										<Type>ComboBox</Type>
+										<Type>CheckBox</Type>
 										<FormControlExtension
 											i:nil="true" />
 										<DataField>IsEnabled</DataField>
-										<DataSource>ISMTelemetryParameters</DataSource>
-										<Items />
+										<DataSource>ISMTelemetryParameterSetup</DataSource>
 									</AxFormControl>
 									<AxFormControl xmlns=""
 										i:type="AxFormComboBoxControl">
@@ -82,7 +81,7 @@
 										<FormControlExtension
 											i:nil="true" />
 										<DataField>SeverityLevel</DataField>
-										<DataSource>ISMTelemetryParameters</DataSource>
+										<DataSource>ISMTelemetryParameterSetup</DataSource>
 										<Items />
 									</AxFormControl>
 								</Controls>

--- a/src/xpp/Metadata/ISMModel/ISMModel/AxFormExtension/SysIntParameters.ISM.xml
+++ b/src/xpp/Metadata/ISMModel/ISMModel/AxFormExtension/SysIntParameters.ISM.xml
@@ -87,7 +87,7 @@
 									</AxFormControl>
 								</Controls>
 								<DataGroup>TelemetryFields</DataGroup>
-								<DataSource>ISMTelemetryParameters</DataSource>
+								<DataSource>ISMTelemetryParameterSetup</DataSource>
 							</AxFormControl>
 						</Controls>
 						<FrameType>None</FrameType>
@@ -103,12 +103,9 @@
 	<DataSourceReferences />
 	<DataSources>
 		<AxFormDataSource xmlns="">
-			<Name>ISMTelemetryParameters</Name>
-			<Table>ISMTelemetryParameters</Table>
+			<Name>ISMTelemetryParameterSetup</Name>
+			<Table>ISMTelemetryParameterSetup</Table>
 			<Fields>
-				<AxFormDataSourceField>
-					<DataField>DataAreaId</DataField>
-				</AxFormDataSourceField>
 				<AxFormDataSourceField>
 					<DataField>IsEnabled</DataField>
 				</AxFormDataSourceField>

--- a/src/xpp/Metadata/ISMModel/ISMModel/AxTable/ISMTelemetryParameterSetup.xml
+++ b/src/xpp/Metadata/ISMModel/ISMModel/AxTable/ISMTelemetryParameterSetup.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <AxTable xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
-	<Name>ISMTelemetryParameters</Name>
+	<Name>ISMTelemetryParameterSetup</Name>
 	<SourceCode>
 		<Declaration><![CDATA[
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-public class ISMTelemetryParameters extends common
+public class ISMTelemetryParameterSetup extends common
 {
 }
 ]]></Declaration>
@@ -19,11 +19,11 @@ public class ISMTelemetryParameters extends common
     /// <param name = "_class"> classname </param>
     /// <param name = "_forupdate">should update </param>
     /// <returns>Returns the record</returns>
-    public static ISMTelemetryParameters find(
+    public static ISMTelemetryParameterSetup find(
         ISMTelemetryClass _class,
         boolean   _forupdate = false)
     {
-        ISMTelemetryParameters    param;
+        ISMTelemetryParameterSetup    param;
 
         if (_class)
         {
@@ -43,8 +43,7 @@ public class ISMTelemetryParameters extends common
 	</SourceCode>
 	<DeveloperDocumentation>@ISM:ISMTelemetryParamDevDoc
 </DeveloperDocumentation>
-	<IsObsolete>Yes</IsObsolete>
-	<Label>@ISM:ISMTelemetryParameters
+	<Label>@ISM:ISMTelemetryParameterSetup
 </Label>
 	<SubscriberAccessLevel>
 		<Read>Allow</Read>
@@ -53,6 +52,7 @@ public class ISMTelemetryParameters extends common
 	<AllowRowVersionChangeTracking>Yes</AllowRowVersionChangeTracking>
 	<CacheLookup>FoundAndEmpty</CacheLookup>
 	<ReplacementKey>TelemetryClass</ReplacementKey>
+	<SaveDataPerCompany>No</SaveDataPerCompany>
 	<DeleteActions />
 	<FieldGroups>
 		<AxTableFieldGroup>


### PR DESCRIPTION
Changing the telemetry parameters table to not save data per company.
THis was not as intended. 

To avoid DB sync issues during deployment, current table was marked obsolete and a new table with same structure was introduced. 