### PR TITLE
switch infolog telemetry to traces

### DIFF
--- a/src/xpp/Metadata/ISMModel/ISMModel/AxClass/ISMTelemetryEventNames.xml
+++ b/src/xpp/Metadata/ISMModel/ISMModel/AxClass/ISMTelemetryEventNames.xml
@@ -29,7 +29,6 @@ public final class ISMTelemetryEventNames
     public const str BusinessEventSavedInCommitLog  = 'BusinessEventSavedInCommitLog';
     public const str BusinessEventSent              = 'BusinessEventSent';
     public const str CostActivateItem               = 'CostActivateItem';
-    public const str InfologMessage                 = 'InfologMessage';
 
 }
 ]]></Declaration>

--- a/src/xpp/Metadata/ISMModel/ISMModel/AxClass/ISMTelemetryInfolog.xml
+++ b/src/xpp/Metadata/ISMModel/ISMModel/AxClass/ISMTelemetryInfolog.xml
@@ -204,7 +204,7 @@ class ISMTelemetryInfolog extends ISMTelemetryBase
             this.addCallStack(contract.parmCompressCallStack());
         }   
 
-        this.processEvent(ISMTelemetryEventNames::InfologMessage);
+        this.processTrace(message, telemetrySeverityLevel);
     }
 
 ]]></Source>


### PR DESCRIPTION
@Hax1337 On second thought, I think traces are a better fit for infolog messages than custom events, mostly because the severity level is part of the trace properties and does not have to be added as a custom property. Though I kept it as a custom property as well, since there is no 1:1 mapping between the infolog and trace severity levels.